### PR TITLE
add brightness_contrast function

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ FileIO
 Images
 RecipesBase
 Interact
+ImageMagick

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ FITSIO 0.12
 FileIO
 Images
 RecipesBase
+Interact

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -4,7 +4,7 @@ module AstroImages
 
 using FITSIO, FileIO, Images, Interact
 
-export load, AstroImage, visualize
+export load, AstroImage
 
 
 """
@@ -75,17 +75,5 @@ Base.convert(::Type{Matrix{C}}, img::AstroImage{T,C}) where {T,C<:Color} = rende
 
 include("showmime.jl")
 include("plot-recipes.jl")
-
-"""
-    visualize(image::AstroImage; brightness_range = 0:255, contrast_range = 1:1000, threshold_range = 1:255)
-
-Visualize the fits image by changing the brightness and contrast of image.
-Users can also provide their own range as keyword arguments.
-"""
-function visualize(img::AstroImage{T,C}; brightness_range = 0:255, contrast_range = 1:1000) where {T,C}
-    @manipulate for brightness  in brightness_range, contrast in contrast_range
-        @. C.((img.data/255 * contrast) + brightness/255)
-    end
-end
 
 end # module

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -76,12 +76,22 @@ Base.convert(::Type{Matrix{C}}, img::AstroImage{T,C}) where {T,C<:Color} = rende
 include("showmime.jl")
 include("plot-recipes.jl")
 
-end # module
+"""
+    visualize(image::AstroImage)
 
+Visualize the fits image by changing the brightness and contrast of image.
+Also, threshold filters out(remove) pixels less than it's value.
+"""
 function visualize(img::AstroImage{T,C}) where {T,C}
-    @manipulate for brightness  in 0:255, contrast in 1:1000
-        tmp = (float.(img.data))./255
-        tmp = ((tmp .* contrast) .+ (brightness/255))
-        colorview(Gray, tmp)
+    @manipulate for brightness  in 0:255, contrast in 1:1000, threshold in 1:255
+        tmp = img.data/255
+     @. tmp = (tmp * contrast) + brightness/255
+        
+        for ind in eachindex(tmp)
+            tmp[ind] = tmp[ind] >= threshold/255 ? tmp[ind] : 0 
+        end
+        colorview(Gray, tmp)             # Currently for GrayScale images only
     end
 end
+
+end # module

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -2,9 +2,9 @@ __precompile__()
 
 module AstroImages
 
-using FITSIO, FileIO, Images
+using FITSIO, FileIO, Images, Interact
 
-export load, AstroImage
+export load, AstroImage, visualize
 
 
 """
@@ -77,3 +77,11 @@ include("showmime.jl")
 include("plot-recipes.jl")
 
 end # module
+
+function visualize(img::AstroImage{T,C}) where {T,C}
+    @manipulate for brightness  in 0:255, contrast in 1:1000
+        tmp = (float.(img.data))./255
+        tmp = ((tmp .* contrast) .+ (brightness/255))
+        colorview(Gray, tmp)
+    end
+end

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -77,20 +77,21 @@ include("showmime.jl")
 include("plot-recipes.jl")
 
 """
-    visualize(image::AstroImage)
+    visualize(image::AstroImage; brightness_range = (0, 255), contrast_range = (1,1000), threshold_range = (1, 255))
 
 Visualize the fits image by changing the brightness and contrast of image.
 Also, threshold filters out(remove) pixels less than it's value.
+Users can also provide their own range as keyword arguments.
 """
-function visualize(img::AstroImage{T,C}) where {T,C}
-    @manipulate for brightness  in 0:255, contrast in 1:1000, threshold in 1:255
+function visualize(img::AstroImage{T,C}; brightness_range = (0, 255), contrast_range = (1,1000), threshold_range = (1, 255)) where {T,C}
+    @manipulate for brightness in brightness_range[1] : brightness_range[2], contrast in contrast_range[1] : contrast_range[2], threshold in threshold_range[1] : threshold_range[2]
         tmp = img.data/255
      @. tmp = (tmp * contrast) + brightness/255
         
         for ind in eachindex(tmp)
             tmp[ind] = tmp[ind] >= threshold/255 ? tmp[ind] : 0 
         end
-        colorview(Gray, tmp)             # Currently for GrayScale images only
+        colorview(Gray, tmp)             # Currently works for GrayScale images only
     end
 end
 

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -77,21 +77,14 @@ include("showmime.jl")
 include("plot-recipes.jl")
 
 """
-    visualize(image::AstroImage; brightness_range = (0, 255), contrast_range = (1,1000), threshold_range = (1, 255))
+    visualize(image::AstroImage; brightness_range = 0:255, contrast_range = 1:1000, threshold_range = 1:255)
 
 Visualize the fits image by changing the brightness and contrast of image.
-Also, threshold filters out(remove) pixels less than it's value.
 Users can also provide their own range as keyword arguments.
 """
-function visualize(img::AstroImage{T,C}; brightness_range = (0, 255), contrast_range = (1,1000), threshold_range = (1, 255)) where {T,C}
-    @manipulate for brightness in brightness_range[1] : brightness_range[2], contrast in contrast_range[1] : contrast_range[2], threshold in threshold_range[1] : threshold_range[2]
-        tmp = img.data/255
-     @. tmp = (tmp * contrast) + brightness/255
-        
-        for ind in eachindex(tmp)
-            tmp[ind] = tmp[ind] >= threshold/255 ? tmp[ind] : 0 
-        end
-        colorview(Gray, tmp)             # Currently works for GrayScale images only
+function visualize(img::AstroImage{T,C}; brightness_range = 0:255, contrast_range = 1:1000) where {T,C}
+    @manipulate for brightness  in brightness_range, contrast in contrast_range
+        @. C.((img.data/255 * contrast) + brightness/255)
     end
 end
 

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -1,3 +1,19 @@
+_brightness_contrast(color, matrix::AbstractMatrix{T}, brightness, contrast) where {T} =
+    @. color(matrix / 255 * T(contrast) + T(brightness) / 255)
+
+"""
+    brightness_contrast(image::AstroImage; brightness_range = 0:255, contrast_range = 1:1000)
+
+Visualize the fits image by changing the brightness and contrast of image.
+Users can also provide their own range as keyword arguments.
+"""
+function brightness_contrast(img::AstroImage{T,C}; brightness_range = 0:255,
+                             contrast_range = 1:1000) where {T,C}
+    @manipulate for brightness  in brightness_range, contrast in contrast_range
+        _brightness_contrast(C, img.data, brightness, contrast)
+    end
+end
+
 # This is used in Jupyter notebooks
 Base.show(io::IO, mime::MIME"image/png", img::AstroImage; kwargs...) =
     show(io, mime, render(img), kwargs...)

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -15,5 +15,5 @@ function brightness_contrast(img::AstroImage{T,C}; brightness_range = 0:255,
 end
 
 # This is used in Jupyter notebooks
-Base.show(io::IO, mime::MIME"image/png", img::AstroImage; kwargs...) =
-    show(io, mime, render(img), kwargs...)
+Base.show(io::IO, mime::MIME"text/html", img::AstroImage; kwargs...) =
+    show(io, mime, brightness_contrast(img), kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-using AstroImages, FITSIO, Images
+using AstroImages, FITSIO, Images, Random, Widgets
 using Test
 
-import AstroImages: _float, render
+import AstroImages: _float, render, _brightness_contrast, brightness_contrast
 
 @testset "Conversion to float and fixed-point" begin
     @testset "Float" begin
@@ -43,6 +43,20 @@ end
         @test convert(Matrix{Gray}, img) == rendered_img
     end
     rm(fname, force=true)
+end
+
+@testset "Control contrast" begin
+    @test @inferred(_brightness_contrast(Gray, ones(Float32, 2, 2), 100, 100)) isa
+          Array{Gray{Float32},2}
+    Random.seed!(1)
+    M = rand(2, 2)
+    @test @inferred(_brightness_contrast(Gray, M, 100, 100)) ≈
+        Gray.([0.48471895908315565  0.514787046406301;
+               0.5280458879184159   0.39525854250610226]) rtol = 1e-12
+    @test @inferred(_brightness_contrast(Gray, M, 0,   255)) == Gray.(M)
+    @test @inferred(_brightness_contrast(Gray, M, 255,   0)) == Gray.(ones(size(M)))
+    @test @inferred(_brightness_contrast(Gray, M,   0,   0)) == Gray.(zeros(size(M)))
+    @test brightness_contrast(AstroImage(M)) isa Widgets.Widget{:manipulate,Any}
 end
 
 include("plots.jl")


### PR DESCRIPTION
A handy function to visualize your fits images by changing brightness and contrast in your Jupyter notebooks.
Currently works for GrayScale images.

- [X] Add `brightness_contrast` function
- [X] Update Docs

- [x] Tweak to accept range from user (brightness and contrast)

Results in IJulia:
![Screenshot from 2019-03-10 10-38-31](https://user-images.githubusercontent.com/23431811/54081348-ad328480-4329-11e9-92a2-911ee8dfc0fb.png)

