### PR TITLE
Multi Image support

### DIFF
--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -60,10 +60,10 @@ end
 Construct an `AstroImage` object of `data`, using `color` as color map, `Gray` by default.
 """
 AstroImage(color::Type{<:Color}, data::Matrix{T}) where {T<:Real} =
-    AstroImage{T,color, 1}(ntuple(i-> data, 1))
+    AstroImage{T,color, 1}((data,))
 AstroImage(color::Type{<:Color}, data::NTuple{N, Matrix{T}}) where {T<:Real, N} =
     AstroImage{T,color, N}(data)
-AstroImage(data::Matrix{T}) where {T<:Real} = AstroImage{T,Gray,1}(ntuple(i-> data, 1))
+AstroImage(data::Matrix{T}) where {T<:Real} = AstroImage{T,Gray,1}((data, ))
 AstroImage(data::NTuple{N, Matrix{T}}) where {T<:Real, N} = AstroImage{T,Gray,N}(data)
 
 """
@@ -118,7 +118,7 @@ Images.colorview(img::AstroImage) = render(img)
 
 Base.size(img::AstroImage) = Base.size.(img.data)
 
-Base.length(img::AstroImage) = Base.length(img.data)
+Base.length(img::AstroImage{T,C,N}) where{T,C,N} = N
 
 include("showmime.jl")
 include("plot-recipes.jl")

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -12,9 +12,10 @@ _load(fits::FITS, ext::NTuple{N, Int}) where {N} = ntuple(i-> read(fits[ext[i]])
 """
     load(fitsfile::String, n=1)
 
-Read and return the data from `n`-th extension of the FITS file.  Second argument can also
-be a tuple of integers, in which case a tuple with the data of each corresponding extension
-is returned.
+Read and return the data from `n`-th extension of the FITS file.
+
+Second argument can also be a tuple of integers, in which case a 
+tuple with the data of each corresponding extension is returned.
 """
 function FileIO.load(f::File{format"FITS"}, ext::Int=1)
     fits = FITS(f.filename)
@@ -54,6 +55,7 @@ end
 
 """
     AstroImage([color=Gray,] data::Matrix{Real})
+    AstroImage(color::Type{<:Color}, data::NTuple{N, Matrix{T}}) where {T<:Real, N}
 
 Construct an `AstroImage` object of `data`, using `color` as color map, `Gray` by default.
 """
@@ -66,8 +68,10 @@ AstroImage(data::NTuple{N, Matrix{T}}) where {T<:Real, N} = AstroImage{T,Gray,N}
 
 """
     AstroImage([color=Gray,] filename::String, n::Int=1)
+    AstroImage(color::Type{<:Color}, file::String, n::NTuple{N, Int}) where {N}
 
 Create an `AstroImage` object by reading the `n`-th extension from FITS file `filename`.
+
 Use `color` as color map, this is `Gray` by default.
 """
 AstroImage(color::Type{<:Color}, file::String, ext::Int) =

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -116,7 +116,9 @@ end
 
 Images.colorview(img::AstroImage) = render(img)
 
-Base.size(img::AstroImage) = Base.size(img.data)
+Base.size(img::AstroImage) = Base.size.(img.data)
+
+Base.length(img::AstroImage) = Base.length(img.data)
 
 include("showmime.jl")
 include("plot-recipes.jl")

--- a/src/plot-recipes.jl
+++ b/src/plot-recipes.jl
@@ -1,10 +1,10 @@
 using RecipesBase
 
-@recipe function f(img::AstroImage)
+@recipe function f(img::AstroImage; header_number = 1)
     seriestype   := :heatmap
     aspect_ratio := :equal
     # Right now we only support single frame images,
     # gray scale is a good choice.
     color        := :grays
-    img.data
+    img.data[header_number]
 end

--- a/src/plot-recipes.jl
+++ b/src/plot-recipes.jl
@@ -1,10 +1,19 @@
 using RecipesBase
 
-@recipe function f(img::AstroImage; header_number = 1)
+@recipe function f(img::AstroImage, header_number::Int)
     seriestype   := :heatmap
     aspect_ratio := :equal
     # Right now we only support single frame images,
     # gray scale is a good choice.
     color        := :grays
     img.data[header_number]
+end
+
+@recipe function f(img::AstroImage)
+    seriestype   := :heatmap
+    aspect_ratio := :equal
+    # Right now we only support single frame images,
+    # gray scale is a good choice.
+    color        := :grays
+    img.data[1]
 end

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -2,15 +2,15 @@ _brightness_contrast(color, matrix::AbstractMatrix{T}, brightness, contrast) whe
     @. color(matrix / 255 * T(contrast) + T(brightness) / 255)
 
 """
-    brightness_contrast(image::AstroImage; brightness_range = 0:255, contrast_range = 1:1000)
+    brightness_contrast(image::AstroImage; brightness_range = 0:255, contrast_range = 1:1000, header_number = 1)
 
 Visualize the fits image by changing the brightness and contrast of image.
 Users can also provide their own range as keyword arguments.
 """
-function brightness_contrast(img::AstroImage{T,C}; brightness_range = 0:255,
-                             contrast_range = 1:1000) where {T,C}
+function brightness_contrast(img::AstroImage{T,C,N}; brightness_range = 0:255,
+                             contrast_range = 1:1000, header_number = 1) where {T,C,N}
     @manipulate for brightness  in brightness_range, contrast in contrast_range
-        _brightness_contrast(C, img.data, brightness, contrast)
+        _brightness_contrast(C, img.data[header_number], brightness, contrast)
     end
 end
 

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -5,6 +5,7 @@ _brightness_contrast(color, matrix::AbstractMatrix{T}, brightness, contrast) whe
     brightness_contrast(image::AstroImage; brightness_range = 0:255, contrast_range = 1:1000, header_number = 1)
 
 Visualize the fits image by changing the brightness and contrast of image.
+
 Users can also provide their own range as keyword arguments.
 """
 function brightness_contrast(img::AstroImage{T,C,N}; brightness_range = 0:255,

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -7,5 +7,5 @@ using RecipesBase
     @test getfield(rec[1], 1) == Dict{Symbol, Any}(:seriestype   => :heatmap,
                                                    :aspect_ratio => :equal,
                                                    :color        => :grays)
-    @test rec[1].args == (img.data,)
+    @test rec[1].args == (img.data[1],)
 end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -8,4 +8,11 @@ using RecipesBase
                                                    :aspect_ratio => :equal,
                                                    :color        => :grays)
     @test rec[1].args == (img.data[1],)
+
+    img = AstroImage((data,data,data))    
+    rec = RecipesBase.apply_recipe(Dict{Symbol, Any}(), img, 2)
+    @test getfield(rec[1], 1) == Dict{Symbol, Any}(:seriestype   => :heatmap,
+                                                   :aspect_ratio => :equal,
+                                                   :color        => :grays)
+    @test rec[1].args == (img.data[1],)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,8 +122,24 @@ end
     rm(fname, force = true)
 end
 
-@testset "Utility functions" begin
-   @test size(AstroImage(rand(10,10))) == (10,10) 
+@testset "multi image AstroImage" begin
+    data1 = rand(10,10)
+    data2 = rand(10,10)
+    fname = tempname() * ".fits"
+    FITS(fname, "w") do f
+        write(f, data1)
+        write(f, data2)
+    end
+
+    img = AstroImage(fname, (1,2))
+    @test length(img.data) == 2
+    @test img.data[1] == data1
+    @test img.data[2] == data2
+
+    img = AstroImage(Gray, FITS(fname), (1,2))
+    @test length(img.data) == 2
+    @test img.data[1] == data1
+    @test img.data[2] == data2
 end
 
 include("plots.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,11 @@ end
     rm(fname, force = true)
 end
 
+@testset "Utility functions" begin
+   @test size(AstroImage((rand(10,10), rand(10,10)))) == ((10,10), (10,10))
+   @test length(AstroImage((rand(10,10), rand(10,10)))) == 2
+end
+
 @testset "multi image AstroImage" begin
     data1 = rand(10,10)
     data2 = rand(10,10)


### PR DESCRIPTION
With this user can hold more than one ImageHDU data in an AstroImage by using-
`AstroImage("file.fits", (2,4,5))`

All required indices should be given in a Tuple.

- [X] Funtion
- [X] Tests
- [X] Docs