### PR TITLE
Mac ci fix

### DIFF
--- a/test/ccd2rgb.jl
+++ b/test/ccd2rgb.jl
@@ -74,6 +74,7 @@ end
         @test img.property.label[1] == ((12,13), "This is an important coordinate")
         @test img.property.label[2] == ((13,11), "This a random coordinate")
 
+        @info "Running..."
         reset!(img)
         @test img.property.contrast == 1.0
         @test img.property.brightness == 0.0


### PR DESCRIPTION
This small trick will fix Mac travis failing builds.
The problem was that I put many tests in a single testset (as they were dependent) and results of tests show up on travis console when all of tests pass or either one of them fail.
Thus it made travis think that the build has gone stale.