### PR TITLE
Bump version to prepare for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AstroImages"
 uuid = "fe3fc30c-9b16-11e9-1c73-17dabf39f4ad"
 authors = ["Mosè Giordano", "Rohit Kumar", "William Thompson"]
-version = "0.4.2"
+version = "0.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
We now use DimensionalData v0.27 and have to drop support for Julia 1.6, 1.7, and 1.8. 
This necessitates a major bump on our part.