### PR TITLE
Update urls for some data downloads

### DIFF
--- a/docs/src/guide/contours.md
+++ b/docs/src/guide/contours.md
@@ -12,7 +12,7 @@ using AstroImages, Plots
 
 # First load a FITS file of interest
 fname = download(
-    "http://www.astro.uvic.ca/~wthompson/astroimages/fits/herca/herca_radio.fits",
+    "https://www.chandra.harvard.edu/photo/2014/archives/fits/herca/herca_radio.fits",
     "herca-radio.fits"
 )
 

--- a/docs/src/guide/image-filtering.md
+++ b/docs/src/guide/image-filtering.md
@@ -17,7 +17,7 @@ using AstroImages
 using ImageFiltering
 
 fname = download(
-    "http://www.astro.uvic.ca/~wthompson/astroimages/fits/herca/herca_radio.fits",
+    "https://www.chandra.harvard.edu/photo/2014/archives/fits/herca/herca_radio.fits",
     "herca-radio.fits"
 )
 
@@ -73,7 +73,7 @@ using AstroImages
 using ImageFiltering
 
 fname = download(
-    "http://www.astro.uvic.ca/~wthompson/astroimages/fits/eagle/673nmos.fits",
+    "https://ds9.si.edu/download/data/673nmos.fits",
     "eagle-673nmos.fits"
 )
 

--- a/docs/src/guide/image-transformations.md
+++ b/docs/src/guide/image-transformations.md
@@ -21,7 +21,7 @@ using AstroImages
 using ImageTransformations
 
 fname = download(
-    "http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/blue.fits",
+    "https://esahubble.org/static/projects/fits_liberator/datasets/antennae/blue.fits",
     "ant-blue.fits"
 )
 

--- a/docs/src/manual/converting-from-rgb.md
+++ b/docs/src/manual/converting-from-rgb.md
@@ -6,7 +6,7 @@ It is possible to store RGB data in an AstroImage. Let's see how that works:
 
 ```@example 1
 using AstroImages
-download("http://www.astro.uvic.ca/~wthompson/astroimages/fits/mw-crop2-small.png","mw-crop2-small.png")
+download("https://upload.wikimedia.org/wikipedia/commons/1/15/154-panel_Widefield_Milky_Way_Panorama.jpg","mw-crop2-small.png")
 
 # First we load it from the PNG file
 mw_png = load("mw-crop2-small.png")

--- a/docs/src/manual/converting-to-rgb.md
+++ b/docs/src/manual/converting-to-rgb.md
@@ -21,23 +21,19 @@ AstroImages.set_cmap!(nothing)
 
 Let's start by downloading the separate color channel FITS files:
 ```@example 1
-# TODO: workaround until stacked images are relocated
+# We crop some of the images a bit to help align them with the other color channels
 antred = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/red.fits"))[:, begin+14:end]
 ```
 ```@example 1
 antgreen = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/green.fits"))
 ```
 ```@example 1
-# TODO: workaround until stacked images are relocated
 antblue = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/blue.fits"))[:, begin+14:end]
 ```
 
 ```@example 1
-# TODO: workaround until stacked images are relocated
 anthalph = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/hydrogen.fits"))[:, begin+14:end]; # Hydrogen-Alpha; we'll revisit later
 ```
-
-The images will have to be aligned and cropped to the same size before making a color composite.
 
 In order to compose these images, we'll have to match the relative intensity scales and clip outlying values.
 Thankfully, `composecolors` handles most of these details automatically.
@@ -46,6 +42,9 @@ Thankfully, `composecolors` handles most of these details automatically.
 rgb1 = composecolors([antred, antgreen, antblue])
 ```
 It's a start!
+
+!!! note
+    For best results, the images should be properly aligned and cropped to the same size before making a color composite. The simple cropping we did here is just for demonstration purposes.
 
 By default, if you provide three images these are mapped to the color channels red, green, and blue.
 The intensities are limited to `Percent(99.5)`.

--- a/docs/src/manual/converting-to-rgb.md
+++ b/docs/src/manual/converting-to-rgb.md
@@ -21,17 +21,20 @@ AstroImages.set_cmap!(nothing)
 
 Let's start by downloading the separate color channel FITS files:
 ```@example 1
-antred = AstroImage(download("http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/red.fits"))
+# TODO: workaround until stacked images are relocated
+antred = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/red.fits"))[:, begin+14:end]
 ```
 ```@example 1
-antgreen = AstroImage(download("http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/green.fits"))
+antgreen = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/green.fits"))
 ```
 ```@example 1
-antblue = AstroImage(download("http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/blue.fits"))
+# TODO: workaround until stacked images are relocated
+antblue = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/blue.fits"))[:, begin+14:end]
 ```
 
 ```@example 1
-anthalph = AstroImage(download("http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/hydrogen.fits")); # Hydrogen-Alpha; we'll revisit later
+# TODO: workaround until stacked images are relocated
+anthalph = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/hydrogen.fits"))[:, begin+14:end]; # Hydrogen-Alpha; we'll revisit later
 ```
 
 The images will have to be aligned and cropped to the same size before making a color composite.

--- a/docs/src/manual/dimensions-and-world-coordinates.md
+++ b/docs/src/manual/dimensions-and-world-coordinates.md
@@ -23,7 +23,7 @@ using Plots
 
 # Download a Hubble image of the Eagle nebula
 download(
-    "http://www.astro.uvic.ca/~wthompson/astroimages/fits/656nmos.fits",
+    "https://ds9.si.edu/download/data/656nmos.fits",
     "eagle-656nmos.fits"
 );
 eagle = load("eagle-656nmos.fits")
@@ -134,7 +134,7 @@ Let's see how this works with a 3D cube.
 ```@example coords
 using AstroImages
 
-HIcube = load(download("http://www.astro.uvic.ca/~wthompson/astroimages/fits/HIdat.fits"))
+HIcube = load(download("https://www.astropy.org/astropy-data/tutorials/FITS-cubes/reduced_TAN_C14.fits"))
 ```
 
 Notice how the cube is not displayed automatically. We have to pick a specific slice:

--- a/docs/src/manual/displaying-images.md
+++ b/docs/src/manual/displaying-images.md
@@ -58,7 +58,7 @@ imview(img; cmap="red")
 Let's now switch to an astronomical image:
 ```@example 1
 fname = download(
-    "http://www.astro.uvic.ca/~wthompson/astroimages/fits/656nmos.fits",
+    "https://ds9.si.edu/download/data/656nmos.fits",
     "eagle-656nmos.fits"
 );
 eagle = AstroImage("eagle-656nmos.fits")


### PR DESCRIPTION
Doc preview: https://juliaastro.org/AstroImages.jl/previews/PR62/

Switched stale urls to some other hosted alternatives. I think I was able to find exact replacements for all of them except the following, which could use some review:

1. `http://www.astro.uvic.ca/~wthompson/astroimages/fits/mw-crop2-small.png` (replaced with https://upload.wikimedia.org/wikipedia/commons/1/15/154-panel_Widefield_Milky_Way_Panorama.jpg)

1. `http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/green.fits` (replaced with https://esahubble.org/static/projects/fits_liberator/datasets/antennae/green.fits)

1. `http://www.astro.uvic.ca/~wthompson/astroimages/fits/antenae/hydrogen.fits` replaced with https://esahubble.org/static/projects/fits_liberator/datasets/antennae/hydrogen.fits

These last two looked to be a bit smaller than their other color channels, so I just trimmed them to match, e.g.,

```julia
# TODO: workaround until stacked images are relocated
antred = AstroImage(download("https://esahubble.org/static/projects/fits_liberator/datasets/antennae/red.fits"))[:, begin+14:end]
```

so that the [color stacking bit of the docs](https://juliaastro.org/AstroImages.jl/previews/PR62/manual/converting-to-rgb/) would run