### PR TITLE
Add separate docs instantiate step

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -23,7 +23,7 @@ jobs:
           version: '1'
       - uses: julia-actions/cache@v2
       - name: Instantiate docs environment
-        shell: julia --color=yes --project=docs
+        shell: julia --color=yes --project=docs {0}
         run: using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()
         env:
           JULIA_PKG_PRECOMPILE_AUTO: 0

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v2
+      - name: Instantiate docs environment
+        shell: julia --color=yes --project=docs
+        run: using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()
+        env:
+          JULIA_PKG_PRECOMPILE_AUTO: 0
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token


### PR DESCRIPTION
This changes pretty much nothing. I'm only adding this because I was debugging CI failure for a different PR, and the documentation workflow had a long log, where a lot of it was just the manifest changes. Precompilation took some up too, but that's necessary because julia-actions/docdeploy stacks it on top of a different environment