### PR TITLE
feat!: Replace FITSIO.jl with FITSFiles.jl

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - fitswcs # TODO: remove after #113 merged
   push:
     branches:
       - main

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ authors = ["Mosè Giordano", "Rohit Kumar", "William Thompson"]
 projects = ["test", "docs"]
 
 [sources]
+FITSFiles = {url = "https://github.com/JuliaAstro/FITSFiles.jl"}
 FITSWCS = {url = "https://github.com/JuliaAstro/FITSWCS.jl"}
 
 [deps]
@@ -14,7 +15,7 @@ AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 AstroAngles = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
-FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
+FITSFiles = "358a0a88-3548-4ad6-b652-8bdbf64af8e5"
 FITSWCS = "b9a10f0d-c86c-4e01-8e2e-1f1d7c5fb3f2"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageAxes = "2803e5a7-5153-5ecf-9a86-9b4c37f5f5ac"
@@ -35,7 +36,7 @@ AbstractFFTs = "1.1"
 AstroAngles = "0.1, 0.2"
 ColorSchemes = "3.18"
 DimensionalData = "0.27, 0.29, 0.30"
-FITSIO = "0.16, 0.17"
+FITSFiles = "0.2, 0.3"
 FITSWCS = "0.1"
 FileIO = "1.15"
 ImageAxes = "0.6"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@
 
 AstroImage.jl is a Julia package for loading, manipulating, and visualizing astronomical images.
 
-It supports FITS files ([FITSIO.jl](https://github.com/JuliaAstro/FITSIO.jl)), world coordinates ([FITSWCS.jl](https://github.com/JuliaAstro/FITSWCS.jl)), rendering images ([Images.jl](https://github.com/JuliaImages/Images.jl)), and plot recipes ([Plots.jl](https://github.com/JuliaPlots/Plots.jl)).
+It supports FITS files ([FITSFiles.jl](https://github.com/JuliaAstro/FITSFiles.jl)), world coordinates ([FITSWCS.jl](https://github.com/JuliaAstro/FITSWCS.jl)), rendering images ([Images.jl](https://github.com/JuliaImages/Images.jl)), and plot recipes ([Plots.jl](https://github.com/JuliaPlots/Plots.jl)).
 
 ## Quickstart
 

--- a/docs/src/manual/headers.md
+++ b/docs/src/manual/headers.md
@@ -71,7 +71,7 @@ history_strings = img[History]
 
 Note that floating point values are formatted as ASCII strings when written to the FITS files, so the precision may be limited.
 
-`AstroImage` objects wrap a FITSIO.jl `FITSHeader`. If necessary, you can recover it using `header(img)`; however, in most cases you can access header keywords directly from the image.
+`AstroImage` objects wrap a vector of FITSFiles.jl `Card`s. If necessary, you can recover it using `header(img)`; however, in most cases you can access header keywords directly from the image.
 
 API docs:
 - [`Comment`](@ref Comment)

--- a/docs/src/manual/loading-and-saving-images.md
+++ b/docs/src/manual/loading-and-saving-images.md
@@ -1,6 +1,6 @@
 # Loading & Saving Images
 
-FITS (Flexible Image Transport System) files can be loaded and saved using AstroImages thanks to the [FITSIO.jl](https://github.com/JuliaAstro/FITSIO.jl) package.
+FITS (Flexible Image Transport System) files can be loaded and saved using AstroImages thanks to the [FITSFiles.jl](https://github.com/JuliaAstro/FITSFiles.jl) package.
 
 AstroImages is registered with [FileIO.jl](https://juliaio.github.io/FileIO.jl/stable/), so if both packages are installed the `FileIO.load` function will work seamlessly with astronomical data. When you pass a file name with the appropriate file extension (".fits", ".fit", ".fits.gz", etc.), FileIO will import AstroImages automatically. For convenience, we also reexport this function from AstroImages:
 

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -5,8 +5,9 @@ using AstroAngles: AstroAngles, deg2dms, deg2hms
 using ColorSchemes: ColorSchemes, get
 using DimensionalData: DimensionalData, AbstractDimArray, At, Dim, Lookups,
     Dimensions, Near, (..), Ti, X, Y, Z, dims, name, rebuild, refdims
-using FITSIO: FITSIO, FITS, FITSHeader, HDU, ImageHDU, TableHDU, get_comment,
-    read_header, set_comment!
+# NB: import selectively — FITSFiles exports `Comment` and `History`, which
+# collide with AstroImages' own header-indexing singletons of the same name.
+using FITSFiles: FITSFiles, fits, HDU, Card
 using FileIO: FileIO, @format_str, File, filename, load, save
 # Rather than pulling in all of Images.jl, just grab the packages
 # We also need ImageShow so that user's images appear automatically.
@@ -26,6 +27,11 @@ using Statistics: Statistics, mean, quantile
 using Tables: Tables
 using UUIDs: UUIDs # can remove once reigstered with FileIO
 using FITSWCS: FITSWCS, WCSTransform, WCS, pixel_to_world, world_to_pixel
+
+# AstroImages stores a FITS header as a vector of FITSFiles `Card`s (each `Card`
+# carries a `.key`, `.value`, and `.comment`). This alias preserves the
+# `FITSHeader` name used throughout the package and as the struct field type.
+const FITSHeader = Vector{Card}
 
 export load,
     save,
@@ -159,16 +165,16 @@ end
 """
     header(img::AstroImage)
 
-Return the underlying FITSIO.FITSHeader object wrapped by an AstroImage.
-Note that this object has less flexible getindex and setindex methods.
-Indexing by symbol, Comment, History, etc are not supported.
+Return the underlying FITS header (a `Vector{FITSFiles.Card}`) wrapped by an
+AstroImage. Note that this object has less flexible getindex and setindex
+methods. Indexing by symbol, Comment, History, etc are not supported.
 """
 header(img::AstroImage) = getfield(img, :header)
 """
     header(array::AbstractArray)
 
-Returns an empty FITSIO.FITSHeader object when called with a non-AstroImage
-abstract array.
+Returns an empty FITS header (a `Vector{FITSFiles.Card}`) when called with a
+non-AstroImage abstract array.
 """
 header(::AbstractArray) = emptyheader()
 
@@ -440,11 +446,37 @@ struct History end
 #     error("getproperty reserved for future use.")
 # end
 
-# Getting and setting comments
-const HeaderValUnion = Union{Float64, String, Nothing, Int64}
-Base.getindex(img::AstroImage, inds::AbstractString...) = getindex(header(img), inds...) # accesing header using strings
+# Getting and setting header values / comments.
+# The header is a `Vector{Card}`; each `Card` carries a `.key`, `.value`, and
+# `.comment`. These helpers reproduce FITSIO's "set or insert" behaviour on top
+# of FITSFiles cards (whose own `setindex!` only updates existing keywords).
+const HeaderValUnion = Union{Bool, Integer, AbstractFloat, AbstractString, Nothing, Missing}
+
+_findcard(cards::FITSHeader, key::AbstractString) =
+    findfirst(c -> uppercase(c.key) == uppercase(key), cards)
+function _setcardvalue!(cards::FITSHeader, key::AbstractString, value)
+    i = _findcard(cards, key)
+    if isnothing(i)
+        push!(cards, Card(key, value))
+    else
+        cards[i] = Card(key, value, cards[i].comment)
+    end
+    return value
+end
+function _getcardcomment(cards::FITSHeader, key::AbstractString)
+    i = _findcard(cards, key)
+    return isnothing(i) ? nothing : cards[i].comment
+end
+function _setcardcomment!(cards::FITSHeader, key::AbstractString, comment)
+    i = _findcard(cards, key)
+    isnothing(i) && throw(KeyError(key))
+    cards[i] = Card(cards[i].key, cards[i].value, comment)
+    return comment
+end
+
+Base.getindex(img::AstroImage, ind::AbstractString) = get(header(img), ind, nothing) # accessing header using strings
 function Base.setindex!(img::AstroImage, v, ind::AbstractString)  # modifying header using a string
-    setindex!(header(img), v, ind)
+    _setcardvalue!(header(img), ind, v)
     # Mark the WCS object as being out of date if this was a WCS header keyword
     if ind ∈ WCS_HEADERS
         getfield(img, :wcs_stale)[] = true
@@ -453,39 +485,28 @@ function Base.setindex!(img::AstroImage, v, ind::AbstractString)  # modifying he
 end
 Base.getindex(img::AstroImage, inds::Symbol...) = getindex(img, string.(inds)...)::HeaderValUnion # accessing header using symbol
 Base.setindex!(img::AstroImage, v, ind::Symbol) = setindex!(img, v, string(ind))
-Base.getindex(img::AstroImage, ind::AbstractString, ::Type{Comment}) = get_comment(header(img), ind) # accesing header comment using strings
-Base.setindex!(img::AstroImage, v, ind::AbstractString, ::Type{Comment}) = set_comment!(header(img), ind, v) # modifying header comment using strings
-Base.getindex(img::AstroImage, ind::Symbol, ::Type{Comment}) = get_comment(header(img), string(ind)) # accessing header comment using symbol
-Base.setindex!(img::AstroImage, v, ind::Symbol, ::Type{Comment}) = set_comment!(header(img), string(ind), v) # modifying header comment using Symbol
+Base.getindex(img::AstroImage, ind::AbstractString, ::Type{Comment}) = _getcardcomment(header(img), ind) # accesing header comment using strings
+Base.setindex!(img::AstroImage, v, ind::AbstractString, ::Type{Comment}) = _setcardcomment!(header(img), ind, v) # modifying header comment using strings
+Base.getindex(img::AstroImage, ind::Symbol, ::Type{Comment}) = _getcardcomment(header(img), string(ind)) # accessing header comment using symbol
+Base.setindex!(img::AstroImage, v, ind::Symbol, ::Type{Comment}) = _setcardcomment!(header(img), string(ind), v) # modifying header comment using Symbol
 
 # Ambiguity fixes for 0-dimensional AstroImages
 Base.getindex(img::AstroImage) = getindex(parent(img))
 Base.setindex!(img::AstroImage, v) = setindex!(parent(img), v)
 
-# Support for special HISTORY and COMMENT entries
-function Base.getindex(img::AstroImage, ::Type{History})
-    hdr = header(img)
-    ii = findall(==("HISTORY"), hdr.keys)
-    return view(hdr.comments, ii)
-end
-function Base.getindex(img::AstroImage, ::Type{Comment})
-    hdr = header(img)
-    ii = findall(==("COMMENT"), hdr.keys)
-    return view(hdr.comments, ii)
-end
+# Support for special HISTORY and COMMENT entries. FITSFiles stores commentary
+# text in the card's `.value` field.
+Base.getindex(img::AstroImage, ::Type{History}) =
+    [c.value for c in header(img) if uppercase(c.key) == "HISTORY"]
+Base.getindex(img::AstroImage, ::Type{Comment}) =
+    [c.value for c in header(img) if uppercase(c.key) == "COMMENT"]
 # Adding new comment and history entries
-function Base.push!(img::AstroImage, ::Type{Comment}, history::AbstractString)
-    hdr = header(img)
-    push!(hdr.keys, "COMMENT")
-    push!(hdr.values, nothing)
-    push!(hdr.comments, history)
+function Base.push!(img::AstroImage, ::Type{Comment}, comment::AbstractString)
+    push!(header(img), Card("COMMENT", comment))
     return
 end
 function Base.push!(img::AstroImage, ::Type{History}, history::AbstractString)
-    hdr = header(img)
-    push!(hdr.keys, "HISTORY")
-    push!(hdr.values, nothing)
-    push!(hdr.comments, history)
+    push!(header(img), Card("HISTORY", history))
     return
 end
 
@@ -555,9 +576,10 @@ Base.convert(::Type{AstroImage{T, N, D, R, AT}}, A::AbstractArray{T, N}) where {
 """
     emptyheader()
 
-Convenience function to create a FITSHeader with no keywords set.
+Convenience function to create an empty FITS header (a `Vector{Card}` with no
+keywords set).
 """
-emptyheader() = FITSHeader(String[], [], String[])
+emptyheader() = Card[]
 
 """
     recenter(img::AstroImage)

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,27 +1,32 @@
-"""
-    AstroImage(fits::FITS, ext::Int=1)
+## Loading
 
-Given an open FITS file from the FITSIO library,
-load the HDU number `ext` as an AstroImage.
 """
-AstroImage(fits::FITS, ext::Int = 1, args...; kwargs...) = AstroImage(fits[ext], args...; kwargs...)
+    AstroImage(hdus::AbstractVector{<:HDU}, ext::Int=1)
+
+Given FITS HDUs read by FITSFiles, load HDU number `ext` as an AstroImage.
+"""
+AstroImage(hdus::AbstractVector{<:HDU}, ext::Int, args...; kwargs...) =
+    AstroImage(hdus[ext], args...; kwargs...)
+function AstroImage(hdus::AbstractVector{<:HDU}; kwargs...)
+    ext = indexer(hdus)
+    return AstroImage(hdus[ext]; kwargs...)
+end
 
 """
     AstroImage(hdu::HDU)
 
-Given an open FITS HDU, load it as an AstroImage.
+Given a FITSFiles HDU, load it as an AstroImage.
 """
-AstroImage(hdu::HDU, args...; kwargs...) = AstroImage(read(hdu), args..., read_header(hdu); kwargs...)
+AstroImage(hdu::HDU, args...; kwargs...) = _loadhdu(hdu, args...; kwargs...)
 
 """
     img = AstroImage(filename::AbstractString, ext::Integer=1)
 
-Load an image HDU `ext` from the  FITS file at `filename` as an AstroImage.
+Load an image HDU `ext` from the FITS file at `filename` as an AstroImage.
 """
 function AstroImage(filename::AbstractString, ext::Integer, args...; kwargs...)
-    return FITS(filename, "r") do fits
-        return AstroImage(fits[ext], args...; kwargs...)
-    end
+    hdus = fits(filename)
+    return AstroImage(hdus[ext], args...; kwargs...)
 end
 """
     img1, img2 = AstroImage(filename::AbstractString, exts)
@@ -43,23 +48,20 @@ function AstroImage(
         args...;
         kwargs...
     ) where {N}
-    return FITS(filename, "r") do fits
-        return map(exts) do ext
-            return AstroImage(fits[ext], args...; kwargs...)
-        end
+    hdus = fits(filename)
+    return map(exts) do ext
+        return AstroImage(hdus[ext], args...; kwargs...)
     end
 end
 function AstroImage(filename::AbstractString; kwargs...)
-    return FITS(filename, "r") do fits
-        ext = indexer(fits)
-        return AstroImage(fits[ext]; kwargs...)
-    end
+    hdus = fits(filename)
+    ext = indexer(hdus)
+    return AstroImage(hdus[ext]; kwargs...)
 end
 function AstroImage(filename::AbstractString, ::Colon, args...; kwargs...)
-    return FITS(filename, "r") do fits
-        return map(fits) do hdu
-            return AstroImage(hdu, args...; kwargs...)
-        end
+    hdus = fits(filename)
+    return map(hdus) do hdu
+        return AstroImage(hdu, args...; kwargs...)
     end
 end
 
@@ -67,66 +69,75 @@ end
 """
     load(fitsfile::String)
 
-Read and return the data from the first ImageHDU in a FITS file
-as an AstroImage. If no ImageHDUs are present, an error is returned.
+Read and return the data from the first image HDU in a FITS file
+as an AstroImage. If no image HDUs are present, an error is returned.
 
     load(fitsfile::String, ext::Int)
 
-Read and return the data from the HDU `ext`. If it is an ImageHDU,
-as AstroImage is returned. If it is a TableHDU, a plain Julia
+Read and return the data from the HDU `ext`. If it is an image HDU,
+an AstroImage is returned. If it is a table HDU, a plain Julia
 column table is returned.
 
     load(fitsfile::String, :)
 
-Read and return the data from each HDU in an FITS file. ImageHDUs are
-returned as AstroImage, and TableHDUs are returned as column tables.
+Read and return the data from each HDU in an FITS file. Image HDUs are
+returned as AstroImage, and table HDUs are returned as column tables.
 
     load(fitsfile::String, exts::Union{NTuple, AbstractArray})
 
-Read and return the data from the HDUs given by `exts`. ImageHDUs are
-returned as AstroImage, and TableHDUs are returned as column tables.
+Read and return the data from the HDUs given by `exts`. Image HDUs are
+returned as AstroImage, and table HDUs are returned as column tables.
 
-!!! Currently any header on TableHDUs are not supported and are ignored.
+!!! Currently any header on table HDUs are not supported and are ignored.
 """
 function fileio_load(f::File{format"FITS"}, ext::Union{Int, Nothing} = nothing, args...; kwargs...)
-    return FITS(f.filename, "r") do fits
-        if isnothing(ext)
-            ext = indexer(fits)
-        end
-        _loadhdu(fits[ext], args...; kwargs...)
+    hdus = fits(f.filename)
+    if isnothing(ext)
+        ext = indexer(hdus)
     end
+    return _loadhdu(hdus[ext], args...; kwargs...)
 end
 function fileio_load(f::File{format"FITS"}, exts::Union{NTuple{N, <:Integer}, AbstractArray{<:Integer}}, args...; kwargs...) where {N}
-    return FITS(f.filename, "r") do fits
-        map(exts) do ext
-            _loadhdu(fits[ext], args...; kwargs...)
-        end
+    hdus = fits(f.filename)
+    return map(exts) do ext
+        _loadhdu(hdus[ext], args...; kwargs...)
     end
 end
 function fileio_load(f::File{format"FITS"}, ::Colon, args...; kwargs...)
-    return FITS(f.filename, "r") do fits
-        exts_resolved = 1:length(fits)
-        map(exts_resolved) do ext
-            _loadhdu(fits[ext], args...; kwargs...)
-        end
+    hdus = fits(f.filename)
+    return map(hdus) do hdu
+        _loadhdu(hdu, args...; kwargs...)
     end
 end
 
-_loadhdu(hdu::FITSIO.TableHDU) = Tables.columntable(hdu)
-function _loadhdu(hdu::FITSIO.ImageHDU, args...; kwargs...)
-    if size(hdu) != ()
-        return AstroImage(hdu, args...; kwargs...)
-    else
-        # Sometimes files have an empty data HDU that shows up as an image HDU but has headers.
-        # Fallback to creating an empty AstroImage with those headers.
+# Header cards attached to an HDU, normalized to the invariant `Vector{Card}`
+# element type that the AstroImage struct field stores.
+_headercards(hdu::HDU) = convert(FITSHeader, hdu.cards)
+
+# Convert a FITSFiles HDU into the appropriate Julia object: image HDUs become
+# AstroImages, table HDUs become column tables (NamedTuples).
+function _loadhdu(hdu::HDU, args...; kwargs...)
+    data = hdu.data
+    if data isa NamedTuple
+        # Table HDU -> Tables.jl column table
+        return data
+    elseif data === missing || (data isa AbstractArray && size(data) == ())
+        # Sometimes files have an empty data HDU that shows up as an image HDU
+        # but has headers. Fall back to creating an empty AstroImage with those
+        # headers.
         emptydata = fill(missing)
-        return AstroImage(emptydata, (), (), read_header(hdu), [emptywcs(emptydata)], Ref(false), ())
+        return AstroImage(emptydata, (), (), _headercards(hdu), [emptywcs(emptydata)], Ref(false), ())
+    else
+        return AstroImage(collect(data), args..., _headercards(hdu); kwargs...)
     end
 end
-function indexer(fits::FITS)
+
+# Index of the first image HDU (at least 1D) in a list of HDUs.
+function indexer(hdus::AbstractVector{<:HDU})
     ext = 0
-    for (i, hdu) in enumerate(fits)
-        if hdu isa ImageHDU && length(size(hdu)) >= 1 # check if Image is atleast 1D
+    for (i, hdu) in enumerate(hdus)
+        data = hdu.data
+        if data isa AbstractArray && ndims(data) >= 1 && size(data) != () # check if Image is atleast 1D
             ext = i
             break
         end
@@ -134,16 +145,35 @@ function indexer(fits::FITS)
     if ext > 1
         @info "Image was loaded from HDU $ext"
     elseif ext == 0
-        error("There are no ImageHDU extensions in '$(fits.filename)'")
+        error("There are no image HDU extensions in the FITS file")
     end
     return ext
 end
-indexer(fits::NTuple{N, FITS}) where {N} = ntuple(i -> indexer(fits[i]), N)
 
+
+## Saving
 
 # Fallback for saving arbitrary arrays
 function fileio_save(f::File{format"FITS"}, args...)
     return writefits(f.filename, args...)
+end
+
+# Structural / column-descriptor keywords are regenerated by FITSFiles from the
+# data when building an HDU, so drop any copies carried in the AstroImage header
+# to avoid duplicate or conflicting cards on write.
+const _STRUCTURAL_HEADER_KEYS = Set(
+    [
+        "SIMPLE", "BITPIX", "NAXIS", "EXTEND", "PCOUNT", "GCOUNT", "XTENSION", "END",
+        "BSCALE", "BZERO", "TFIELDS",
+    ]
+)
+function _writablecards(cards::FITSHeader)
+    return Card[
+        c for c in cards
+            if !(uppercase(c.key) in _STRUCTURAL_HEADER_KEYS) &&
+            !occursin(r"^NAXIS\d+$", uppercase(c.key)) &&
+            !occursin(r"^T(TYPE|FORM|UNIT|SCAL|ZERO|DIM|NULL|DISP)\d+$", uppercase(c.key))
+    ]
 end
 
 """
@@ -154,34 +184,43 @@ Write arguments to a FITS file.
 See also [`FileIO.save`](@ref)
 """
 function writefits(fname, args...)
-    return FITS(fname, "w") do fits
-        for arg in args
-            writearg(fits, arg)
+    hdus = HDU[]
+    for arg in args
+        # A FITS file must begin with a Primary (image) HDU. If the first
+        # argument is a table, prepend an empty Primary HDU.
+        if isempty(hdus) && !_isimagearg(arg)
+            push!(hdus, HDU(FITSFiles.Primary, missing))
         end
+        push!(hdus, _tohdu(arg, isempty(hdus)))
     end
+    write(fname, hdus)
+    return
 end
+
+_isimagearg(::AbstractArray) = true
+_isimagearg(_) = false
+
 parent_recurse(img::AbstractArray) = img
 parent_recurse(img::AstroImage) = parent_recurse(parent(img))
-writearg(fits, img::AstroImage) = write(fits, parent_recurse(img), header = header(img))
-# Fallback for writing plain arrays
-writearg(fits, arr::AbstractArray) = write(fits, arr)
+
+# Build an HDU for a writeable argument. `primary=true` requests a Primary HDU
+# (only valid as the first HDU in a file); otherwise an image extension HDU.
+function _tohdu(img::AstroImage, primary::Bool)
+    hdutype = primary ? FITSFiles.Primary : FITSFiles.Image
+    return HDU(hdutype, collect(parent_recurse(img)), _writablecards(header(img)))
+end
+function _tohdu(arr::AbstractArray, primary::Bool)
+    hdutype = primary ? FITSFiles.Primary : FITSFiles.Image
+    return HDU(hdutype, collect(arr))
+end
 # For table compatible data.
 # This allows users to round trip: dat = load("abc.fits", :); write("abc", dat)
 # when it contains FITS tables.
-function writearg(fits, table)
+function _tohdu(table, ::Bool)
     if !Tables.istable(table)
         error("Cannot save argument to FITS file. Value is not an AbstractArray or table.")
     end
-    # FITSIO has fairly restrictive input types for writing tables (assertions for documentation only)
-    colname_strings = string.(collect(Tables.columnnames(table)))::Vector{String}
-    columns = collect(Tables.columns(table))::Vector
-    return write(
-        fits,
-        colname_strings,
-        columns;
-        hdutype = TableHDU,
-        # TODO: In future, we want to be able to access and round-trip coments
-        # on table HDUs
-        # header = nothing
-    )
+    # TODO: In future, we want to be able to access and round-trip comments on
+    # table HDUs.
+    return HDU(FITSFiles.Bintable, Tables.columntable(table))
 end

--- a/src/wcs.jl
+++ b/src/wcs.jl
@@ -265,10 +265,10 @@ core per-axis keywords (e.g. `CTYPE1A`, `CRVAL2B`). The result is sorted, so the
 primary (if any) comes first. An empty result means the header carries no WCS.
 """
 const _WCS_ALT_KEY_RE = r"^(?:CTYPE|CRVAL|CRPIX|CDELT|CUNIT|CROTA)\d+([A-Z]?)$"
-function wcsalts(hdr)
+function wcsalts(cards)
     alts = Set{Char}()
-    for key in keys(hdr)
-        m = match(_WCS_ALT_KEY_RE, uppercase(String(key)))
+    for card in cards
+        m = match(_WCS_ALT_KEY_RE, uppercase(String(card.key)))
         m === nothing && continue
         suffix = m.captures[1]
         push!(alts, isempty(suffix) ? ' ' : suffix[1])
@@ -292,7 +292,7 @@ function wcsfromheader(img::AstroImage)
     wcsout = WCSTransform[]
     for alt in wcsalts(hdr)
         try
-            # FITSWCS parses the FITSIO header directly via its FITSIO extension.
+            # FITSWCS parses the FITSFiles header cards via its FITSFiles extension.
             push!(wcsout, WCS(hdr; alt))
         catch err
             @warn "Failed to parse WCS information (alt=$(repr(alt))); it may be malformed." exception = err

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 AstroImages = "fe3fc30c-9b16-11e9-1c73-17dabf39f4ad"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
+FITSFiles = "358a0a88-3548-4ad6-b652-8bdbf64af8e5"
 FITSWCS = "b9a10f0d-c86c-4e01-8e2e-1f1d7c5fb3f2"
 ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
@@ -12,7 +12,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Documenter = "1"
-FITSIO = "0.16, 0.17"
+FITSFiles = "0.3"
 ImageBase = "0.1.5"
 ParallelTestRunner = "2.6.2"
 RecipesBase = "1.2"

--- a/test/general.jl
+++ b/test/general.jl
@@ -3,7 +3,8 @@ using AstroImages:
     # Stretches
     sqrtstretch, asinhstretch, powerdiststretch, logstretch, powstretch, squarestretch, sinhstretch
 
-using FITSIO: FITS, FITSHeader, read_header
+using FITSFiles: fits, HDU, Card
+using FITSFiles: Primary, Image, Bintable
 
 using ImageBase: Gray, RGBA, Normed, N0f8, N0f16, N0f32, N0f64
 
@@ -37,14 +38,15 @@ end
 
 @testset "FITS and images" begin
     fname = tempname() * ".fits"
+    # Standard FITS BITPIX element types. FITSFiles does not (yet) write the
+    # non-native integer types (Int8, UInt16, UInt32) that FITSIO supported via
+    # BSCALE/BZERO scaling.
     for T in [
-            UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
+            UInt8, Int16, Int32, Int64,
             Float32, Float64,
         ]
         data = reshape(T[1:100;], 5, 20)
-        FITS(fname, "w") do f
-            write(f, data)
-        end
+        write(fname, HDU[HDU(Primary, data)])
         @test load(fname, 1) == data
         @test load(fname, (1, 1)) == (data, data)
         img = AstroImage(fname)
@@ -58,63 +60,41 @@ end
     fname = tempname() * ".fits"
     @testset "less dimensions than 2" begin
         data = rand(2)
-        FITS(fname, "w") do f
-            write(f, data)
-        end
+        write(fname, HDU[HDU(Primary, data)])
         @test ndims(AstroImage(fname)) == 1
     end
 
     @testset "no ImageHDU" begin
-        ## Binary table
-        indata = Dict{String, Array}()
-        i = length(indata) + 1
-        indata["col$i"] = [randstring(10) for j in 1:20]  # ASCIIString column
-        i += 1
-        indata["col$i"] = ones(Bool, 20)  # Bool column
-        i += 1
-        indata["col$i"] = reshape([1:40;], (2, 20))  # vector Int64 column
-        i += 1
-        indata["col$i"] = [randstring(5) for j in 1:2, k in 1:20]  # vector ASCIIString col
-        indata["vcol"] = [randstring(j) for j in 1:20]  # variable length column
-        indata["VCOL"] = [collect(1.0:j) for j in 1.0:20.0] # variable length
-
-        FITS(fname, "w") do f
-            write(f, indata; varcols = ["vcol", "VCOL"])
-            @test_throws Exception AstroImage(f)
-        end
+        # A file whose only HDUs are an empty primary and a binary table.
+        write(
+            fname, HDU[
+                HDU(Primary, missing),
+                HDU(Bintable, (col1 = Int32[1:20;], col2 = ones(Bool, 20))),
+            ]
+        )
+        hdus = fits(fname)
+        @test_throws Exception AstroImage(hdus)
     end
 
     @testset "Opening AstroImage in different ways" begin
         data = rand(2, 2)
-        FITS(fname, "w") do f
-            write(f, data)
-        end
-        f = FITS(fname)
-        header = read_header(f[1])
+        write(fname, HDU[HDU(Primary, data)])
+        hdus = fits(fname)
+        header = convert(Vector{Card}, hdus[1].cards)
         @test AstroImage(fname, 1) isa AstroImage
-        @test AstroImage(f, 1) isa AstroImage
+        @test AstroImage(hdus, 1) isa AstroImage
         @test AstroImage(data, header) isa AstroImage
-        close(f)
     end
 
     @testset "Image HDU is not at 1st position" begin
-        ## Binary table
-        indata = Dict{String, Array}()
-        i = length(indata) + 1
-        indata["col$i"] = [randstring(10) for j in 1:20]  # ASCIIString column
-        i += 1
-        indata["col$i"] = ones(Bool, 20)  # Bool column
-        i += 1
-        indata["col$i"] = reshape([1:40;], (2, 20))  # vector Int64 column
-        i += 1
-        indata["col$i"] = [randstring(5) for j in 1:2, k in 1:20]  # vector ASCIIString col
-        indata["vcol"] = [randstring(j) for j in 1:20]  # variable length column
-        indata["VCOL"] = [collect(1.0:j) for j in 1.0:20.0] # variable length
-
-        FITS(fname, "w") do f
-            write(f, indata; varcols = ["vcol", "VCOL"])
-            write(f, rand(2, 2))
-        end
+        # Empty primary, then a binary table, then the image at HDU 3.
+        write(
+            fname, HDU[
+                HDU(Primary, missing),
+                HDU(Bintable, (col1 = Int32[1:20;], col2 = ones(Bool, 20))),
+                HDU(Image, rand(2, 2)),
+            ]
+        )
 
         @test @test_logs (:info, "Image was loaded from HDU 3") AstroImage(fname) isa AstroImage
     end
@@ -128,91 +108,37 @@ end
 
 @testset "multi wcs AstroImage" begin
     fname = tempname() * ".fits"
-    f = FITS(fname, "w")
-    inhdr = FITSHeader(
-        [
-            "FLTKEY", "INTKEY", "BOOLKEY", "STRKEY", "COMMENT", "HISTORY",
-            "CRVAL1a",
-            "CRVAL2a",
-            "CRPIX1a",
-            "CRPIX2a",
-            "CDELT1a",
-            "CDELT2a",
-            "CTYPE1a",
-            "CTYPE2a",
-            "CUNIT1a",
-            "CUNIT2a",
+    inhdr = Card[
+        Card("FLTKEY", 1.0, "floating point keyword"),
+        Card("INTKEY", 1, ""),
+        Card("BOOLKEY", true, "boolean keyword"),
+        Card("STRKEY", "string value", "string value"),
+        Card("COMMENT", "this is a comment"),
+        Card("HISTORY", "this is a history"),
 
-            "CRVAL1b",
-            "CRVAL2b",
-            "CRPIX1b",
-            "CRPIX2b",
-            "CDELT1b",
-            "CDELT2b",
-            "CTYPE1b",
-            "CTYPE2b",
-            "CUNIT1b",
-            "CUNIT2b",
-        ],
-        [
-            1.0, 1, true, "string value", nothing, nothing,
-            0.5,
-            89.5,
-            1,
-            1,
-            1,
-            -1,
-            "RA---TAN",
-            "DEC--TAN",
-            "deg     ",
-            "deg     ",
+        Card("CRVAL1A", 0.5), Card("CRVAL2A", 89.5),
+        Card("CRPIX1A", 1), Card("CRPIX2A", 1),
+        Card("CDELT1A", 1), Card("CDELT2A", -1),
+        Card("CTYPE1A", "RA---TAN", "Terrestrial East Longitude"),
+        Card("CTYPE2A", "DEC--TAN", "Terrestrial North Latitude"),
+        Card("CUNIT1A", "deg"), Card("CUNIT2A", "deg"),
 
-            0.5,
-            89.5,
-            1,
-            1,
-            1,
-            -1,
-            "RA---TAN",
-            "DEC--TAN",
-            "deg     ",
-            "deg     ",
-        ],
-        [
-            "floating point keyword", "", "boolean keyword", "string value", "this is a comment", "this is a history",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "Terrestrial East Longitude",
-            "Terrestrial North Latitude",
-            "",
-            "",
-
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "Terrestrial East Longitude",
-            "Terrestrial North Latitude",
-            "",
-            "",
-        ]
-    )
+        Card("CRVAL1B", 0.5), Card("CRVAL2B", 89.5),
+        Card("CRPIX1B", 1), Card("CRPIX2B", 1),
+        Card("CDELT1B", 1), Card("CDELT2B", -1),
+        Card("CTYPE1B", "RA---TAN", "Terrestrial East Longitude"),
+        Card("CTYPE2B", "DEC--TAN", "Terrestrial North Latitude"),
+        Card("CUNIT1B", "deg"), Card("CUNIT2B", "deg"),
+    ]
 
     indata = reshape(Float32[1:100;], 5, 20)
-    write(f, indata; header = inhdr)
-    close(f)
+    write(fname, HDU[HDU(Primary, indata, inhdr)])
 
     # Sample pixels for a pixel -> world -> pixel round-trip check.
     testpix = ([1.0, 1.0], [2.5, 10.0], [5.0, 20.0])
 
     img = AstroImage(fname)
-    f = FITS(fname)
+    hdus = fits(fname)
     @test length(wcs(img)) == 2
     for n in 1:2
         w = wcs(img, n)
@@ -222,7 +148,7 @@ end
         end
     end
 
-    img = AstroImage(f)
+    img = AstroImage(hdus)
     @test length(wcs(img)) == 2
     for n in 1:2
         w = wcs(img, n)
@@ -231,7 +157,6 @@ end
             @test world_to_pixel(w, pixel_to_world(w, p)) ≈ p rtol = 1.0e-8
         end
     end
-    close(f)
 end
 
 ##


### PR DESCRIPTION
Depends on #113

Migrates AstroImages.jl FITS I/O and header handling from [FITSIO.jl](https://github.com/JuliaAstro/FITSIO.jl) (a CFITSIO/C wrapper) to the pure-Julia [FITSFiles.jl](https://github.com/JuliaAstro/FITSFiles.jl).

## Motivation

- Removes the last C/binary dependency in the core load/save path.
- Keeps the stack within the JuliaAstro pure-Julia ecosystem (FITSFiles + FITSWCS), improving portability and composability.

## What changed

**Header model** (`src/AstroImages.jl`)

- The wrapped header is now a `Vector{FITSFiles.Card}` (each `Card` carries `.key` / `.value` / `.comment`) instead of a `FITSIO.FITSHeader`. Kept under the internal `FITSHeader` alias and as the struct field type.
- Import is **selective** (`using FITSFiles: fits, HDU, Card`) to avoid FITSFiles' exported `Comment` / `History` colliding with AstroImages.jl's own
header-indexing singletons of the same name.
- Reimplemented `emptyheader`, keyword value get/set, `get_comment` / `set_comment!`, the `History` / `Comment` views, and `push!(img, Comment/History, str)` against the card model. FITSFiles stores commentary text in `card.value`. The **public API is unchanged**, `img["KEY"]`, `img["KEY", Comment]`, `img[History]`, etc. all behave as before.

**I/O** (`src/io.jl`)

- Rewritten on `fits()` / `HDU` / `hdu.data`. Image HDUs --> `AstroImage`; table HDUs --> column tables (`NamedTuple`); empty/dataless HDUs --> empty `AstroImage` carrying the header.
- Saving builds `HDU`s directly: images --> `HDU(Primary/Image, data, cards)`, tables --> `HDU(Bintable, ...)`. Structural/column-descriptor keywords (`SIMPLE`, `BITPIX`, `NAXISⁿ`, `TFORMⁿ`, ...) are stripped before write so FITSFiles regenerates them consistently with the data.

**WCS** (`src/wcs.jl`)

- `wcsfromheader` now parses header cards via the `FITSWCSFITSFilesExt` bridge (`WCS(cards; alt)`) instead of the FITSIO extension. `wcsalts` iterates `card.key`. Multi-alt support is preserved.

**Tests & docs**

- `test/general.jl` fixtures rebuilt with FITSFiles (`write(fname, HDU[…])`, `Card[...]` headers).
- Doc prose references to FITSIO.jl / `FITSHeader` updated to FITSFiles.jl / `Card`.

## ⚠️  Breaking / behavior changes

- **`header(img)` return type** changes from `FITSIO.FITSHeader` to `Vector{FITSFiles.Card}`. Code that reached into the raw header object (e.g., FITSIO-specific methods, or `.keys`/`.values`/`.comments`) must be updated. The `AstroImage`-level header API is unchanged.
- **Non-native integer image types dropped on write.** FITSFiles v0.3.2 writes only standard BITPIX types (`UInt8, Int16, Int32, Int64, Float32, Float64`); `Int8` / `UInt16` / `UInt32` (which FITSIO supported via `BSCALE`/`BZERO`) are no longer written. The write test loop was trimmed accordingly.
- **Variable-length table columns (`varcols`)** are not supported by FITSFiles; affected test fixtures now use fixed-width columns.