### PR TITLE
fix(wcs)!: Integrate AstroImages.jl with `FITSWCS.slice_wcs`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ projects = ["test", "docs"]
 
 [sources]
 FITSFiles = {url = "https://github.com/JuliaAstro/FITSFiles.jl"}
-FITSWCS = {rev = "slices-astroimages", url = "https://github.com/JuliaAstro/FITSWCS.jl"}
+FITSWCS = {url = "https://github.com/JuliaAstro/FITSWCS.jl"}
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ projects = ["test", "docs"]
 
 [sources]
 FITSFiles = {url = "https://github.com/JuliaAstro/FITSFiles.jl"}
-FITSWCS = {url = "https://github.com/JuliaAstro/FITSWCS.jl"}
+FITSWCS = {rev = "slices-astroimages", url = "https://github.com/JuliaAstro/FITSWCS.jl"}
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/AstroImages.jl
+++ b/src/AstroImages.jl
@@ -26,7 +26,7 @@ using RecipesBase: RecipesBase, @layout, @recipe, @series, @userplot
 using Statistics: Statistics, mean, quantile
 using Tables: Tables
 using UUIDs: UUIDs # can remove once reigstered with FileIO
-using FITSWCS: FITSWCS, WCSTransform, WCS, WCS_all, pixel_to_world, world_to_pixel
+using FITSWCS: FITSWCS, WCSTransform, WCS, WCS_all, pixel_to_world, world_to_pixel, slice_wcs
 
 # AstroImages stores a FITS header as a vector of FITSFiles `Card`s (each `Card`
 # carries a `.key`, `.value`, and `.comment`). This alias preserves the
@@ -245,7 +245,12 @@ DimensionalData.metadata(::AstroImage) = Lookups.NoMetadata()
         # Cached WCSTransform objects for this data
         wcs::AbstractDict{Char, <:WCSTransform} = getfield(img, :wcs),
         wcs_stale::Bool = getfield(img, :wcs_stale)[],
-        wcsdims::Tuple = (dims..., refdims...),
+        # `wcsdims` records the parent image's dim --> WCS axis correspondence,
+        # so it must survive slicing/permutation unchanged (categorical refdims are
+        # located within it, and `wcsax` derives axis numbers from its order).
+        # DimensionalData may route slicing through either `rebuild` method
+        # directly, so preserve it here rather than recomputing from the (possibly sliced) dims.
+        wcsdims::Tuple = getfield(img, :wcsdims),
     )
     return AstroImage(data, dims, refdims, header, wcs, Ref(wcs_stale), wcsdims)
 end
@@ -265,7 +270,7 @@ end
         # Cached WCSTransform objects for this data
         wcs::AbstractDict{Char, <:WCSTransform} = getfield(img, :wcs),
         wcs_stale::Bool = getfield(img, :wcs_stale)[],
-        wcsdims::Tuple = (dims..., refdims...),
+        wcsdims::Tuple = getfield(img, :wcsdims),
     )
     return AstroImage(data, dims, refdims, header, wcs, Ref(wcs_stale), wcsdims)
 end

--- a/src/wcs.jl
+++ b/src/wcs.jl
@@ -341,201 +341,186 @@ function _stokes_name(symb)
     end
 end
 
+# Coerce a coordinate vector/matrix to `Float64` without copying when possible
+_f64(x::AbstractArray{Float64}) = x
+_f64(x::Tuple) = collect(Float64, x)
+_f64(x) = Float64.(x)
 
-# Dimension-aware wrappers that extend FITSWCS's `pixel_to_world` / `world_to_pixel`
-# with methods accepting an `AstroImage`: they handle dims/refdims, slicing, and
-# coordinate scaling, then delegate the projection to the underlying `WCSTransform`.
+# Reorder the coordinate axes (rows) of a coordinate vector/matrix by `perm`
+_permrows(x::AbstractVector, perm) = x[perm]
+_permrows(x::AbstractMatrix, perm) = x[perm, :]
+
+# WCS axis number of each selected dim, in `dims(img)` order
+_wcsaxes(img::AstroImage) = Int[wcsax(img, d) for d in dims(img)]
+
+# Frozen parent-frame pixel position of a dropped reference dimension.
+# Numeric refdims carry the position directly in their lookup value (fractional values are allowed).
+# Categorical ones (e.g. a Stokes axis of symbols I/Q/U) are located within the full parent dimension retained in `wcsdims`.
+function _refindex(img::AstroImage, refdim)
+    if eltype(refdim) <: Number
+        return first(refdim)
+    end
+    wcsdimtuple = getfield(img, :wcsdims)
+    parentdim = wcsdimtuple[findfirst(d -> name(d) == name(refdim), wcsdimtuple)]
+    return findfirst(==(first(refdim)), collect(parentdim))
+end
+
+# Build the `SlicedWCSTransform` describing `img`'s current view of `wcsn`.
+# Each kept dim contributes its parent-pixel range (`first:step:last`), each dropped refdim its frozen parent-pixel position.
+# WCS axes beyond the image's dim bookkeeping (e.g. degenerate header axes) are frozen at the reference pixel.
+function _slicedwcs(img::AstroImage, wcsn)
+    w = wcs(img, wcsn)
+    wcsdimtuple = getfield(img, :wcsdims)
+    keptnames = map(name, dims(img))
+    slices = ntuple(w.naxis) do j
+        j > length(wcsdimtuple) && return w.crpix[j]
+        wd = wcsdimtuple[j]
+        di = findfirst(==(name(wd)), keptnames)
+        if di === nothing
+            _refindex(img, refdims(img)[findfirst(rd -> name(rd) == name(wd), refdims(img))])
+        else
+            d = dims(img)[di]
+            first(d):step(d):last(d)
+        end
+    end
+    return slice_wcs(w, slices...)
+end
+
+# Permutation from `dims(img)` order to the sliced WCS's axis slots.
+# Its kept axes are ordered by ascending parent-WCS-axis index.
+function _sliceperm(img::AstroImage)
+    kept = sort!([wcsax(img, d) for d in dims(img)])
+    return Int[findfirst(==(wcsax(img, d)), kept) for d in dims(img)]
+end
+
+# Expand dims-ordered coordinates into a full parent-frame pixel buffer in WCS axis order.
+# Kept dims map slice-local --> parent via their lookup (or pass through unchanged when `parent=true`).
+# Frozen refdims fill their slots, and any remaining axes stay at the reference pixel.
+function _parentpixels(img::AstroImage, pix::AbstractVecOrMat, wcsn, parent::Bool)
+    w = wcs(img, wcsn)
+    P = ndims(pix) > 1 ? repeat(Vector(w.crpix), 1, size(pix, 2)) : Vector{Float64}(w.crpix)
+    for (i, d) in enumerate(dims(img))
+        j = wcsax(img, d)
+        if parent
+            P[j, :] .= pix[i, :]
+        else
+            P[j, :] .= (pix[i, :] .- 1) .* step(d) .+ first(d)
+        end
+    end
+    for rd in refdims(img)
+        P[wcsax(img, rd), :] .= _refindex(img, rd)
+    end
+    return P
+end
+
 """
-    pixel_to_world(img::AstroImage, pixcoords; all=false)
+    pixel_to_world(img::AstroImage, pixcoords; wcsn = ' ', all = false, parent = false)
 
-Given an astro image, look up the world coordinates of the pixels given
-by `pixcoords`. World coordinates are resolved using FITSWCS.jl and a
-WCSTransform calculated from any FITS header present in `img`. If
-no WCS information is in the header, or the axes are all linear, this will
-just return pixel coordinates.
+Given an `AstroImage`, look up the world coordinates of the pixels given by `pixcoords`
+using FITSWCS.jl and a WCSTransform calculated from any FITS header present in `img`.
+If no WCS information is in the header, or the axes are all linear, this will just return pixel coordinates.
 
-`pixcoords` should be the coordinates in your current selection
-of the image. For example, if you select a slice like this:
+`pixcoords` may be a vector (one coordinate) or a matrix whose columns are coordinates,
+given in the order of `dims(img)`, i.e., 1-based positions within your current selection of the image.
+For example, if you select a slice like this:
+
 ```julia-repl
 julia> cube = load("some-3d-cube.fits")
 julia> slice = cube[10:20, 30:40, 5]
 ```
 
-Then to look up the coordinates of the pixel in the bottom left corner of
-`slice`, run:
+Then to look up the coordinates of the pixel in the bottom left corner of `slice`, run:
+
 ```julia-repl
-julia> world_coords = pixel_to_world(img, [1, 1])
+julia> world_coords = pixel_to_world(slice, [1, 1])
 [10, 30]
 ```
 
 If WCS information was present in the header of `cube`, then those coordinates
 would be resolved using axis 1, 2, and 3 respectively.
 
-To include world coordinates in all axes, pass `all=true`
-```julia-repl
-julia> world_coords = pixel_to_world(img, [1, 1], all=true)
-[10, 30, 5]
-```
+Keyword arguments:
 
-!! Coordinates must be provided in the order of `dims(img)`. If you transpose
-an image, the order you pass the coordinates should not change.
+- `wcsn`: Which WCS version character to use (`' '` for the primary system, `'A'`–`'Z'` for alternates).
+- `all=true`: Return world coordinates for **all** WCS axes (in WCS axis order),
+  including axes frozen by slicing, instead of only the selected dims.
+- `parent=true`: Interpret `pixcoords` as 1-based pixel positions in the parent (original) array,
+   rather than in the current slice.
+
+Note: Coordinates must be provided in the order of `dims(img)`. If you transpose an image,
+the order you pass the coordinates should not change.
 """
 function FITSWCS.pixel_to_world(img::AstroImage, pixcoords; wcsn = ' ', all = false, parent = false)
-    if pixcoords isa Array{Float64}
-        pixcoords_prepared = pixcoords
-    else
-        pixcoords_prepared = [Float64(c) for c in pixcoords]
-    end
-    # Find the coordinates in the parent array.
-    # Dimensional data
-    # pixcoords_floored = floor.(Int, pixcoords)
-    # pixcoords_frac = (pixcoords .- pixcoords_floored) .* step.(dims(img))
-    # parentcoords = getindex.(dims(img), pixcoords_floored) .+ pixcoords_frac
-    if parent
-        parentcoords = pixcoords
-    else
-        parentcoords = pixcoords .* step.(dims(img)) .+ first.(dims(img))
-    end
-    # Build a Float64 buffer sized to the WCS's full axis count; the loops below
-    # scatter this image's dims/refdims into their WCS-axis positions.
-    # TODO: avoid allocation in case where refdims=() and pixcoords isa Array{Float64}
-    if ndims(pixcoords_prepared) > 1
-        parentcoords_prepared = zeros(wcs(img, wcsn).naxis, size(pixcoords_prepared, 2))
-    else
-        parentcoords_prepared = zeros(wcs(img, wcsn).naxis)
-    end
-    # out = zeros(Float64, wcs(img,wcsn).naxis, size(pixcoords,2))
-    for (i, dim) in enumerate(dims(img))
-        j = wcsax(img, dim)
-        parentcoords_prepared[j, :] .= parentcoords[i, :] .- 1
-    end
-    for dim in refdims(img)
-        j = wcsax(img, dim)
-        # Non numeric reference dims can be used, e.g. a polarization axis of symbols I, Q, U, etc.
-        if eltype(dim) <: Number
-            z = dim[1] - 1
-        else
-            # Find the index of the symbol into the parent cube
-            parentrefdim = img.wcsdims[findfirst(d -> name(d) == name(dim), img.wcsdims)]
-            z = findfirst(==(first(dim)), collect(parentrefdim)) - 1
-        end
-        parentcoords_prepared[j, :] .= z
-    end
-
-    # Get world coordinates along all slices.
-    worldcoords_out = pixel_to_world(wcs(img, wcsn), parentcoords_prepared)
-
-    # If user requested world coordinates in all dims, not just selected
-    # dims of img
-    if all
-        return worldcoords_out
-    end
-
-    # Otherwise filter to only return coordinates along selected dims.
-    if ndims(pixcoords_prepared) > 1
-        world_coords_of_these_axes = zeros(length(dims(img)), size(pixcoords_prepared, 2))
-    else
-        world_coords_of_these_axes = zeros(length(dims(img)))
-    end
-    for (i, dim) in enumerate(dims(img))
-        j = wcsax(img, dim)
-        world_coords_of_these_axes[i, :] .= worldcoords_out[j, :]
-    end
-
-    return world_coords_of_these_axes
+    pix = _f64(pixcoords)
+    size(pix, 1) == length(dims(img)) || throw(
+        DimensionMismatch(
+            "Got $(size(pix, 1)) pixel coordinates but the image has $(length(dims(img))) dimensions."
+        )
+    )
+    worldcoords = pixel_to_world(wcs(img, wcsn), _parentpixels(img, pix, wcsn, parent))
+    # Return every WCS axis, or filter to the axes of the selected dims.
+    return all ? worldcoords : _permrows(worldcoords, _wcsaxes(img))
 end
 
 
 """
-    world_to_pixel(img::AstroImage, worldcoords)
+    world_to_pixel(img::AstroImage, worldcoords; wcsn = ' ', parent = false)
 
-Given an astro image, look up the pixel coordinates corresponding to the world
-coordinates `worldcoords`. This is the inverse of [`pixel_to_world`](@ref): world
-coordinates are resolved using FITSWCS.jl and a WCSTransform calculated from any
-FITS header present in `img`. If no WCS information is in the header, or the axes
-are all linear, this just returns the input coordinates.
+Given an `AstroImage`, look up the pixel coordinates corresponding to
+the world coordinates `worldcoords`. This is the inverse of [`pixel_to_world`](@ref).
+World coordinates are resolved using FITSWCS.jl and a WCSTransform calculated from any
+FITS header present in `img`. If no WCS information is in the header, or
+the axes are all linear, this just returns the input coordinates.
 
-The returned pixel coordinates need not lie within the bounds of the image, and
-in general lie at fractional pixel positions.
+`worldcoords` may be a vector (one coordinate) or a matrix whose columns are coordinates,
+given in the order of `dims(img)`. The returned pixel coordinates need not lie within the bounds of the image,
+and in general lie at fractional pixel positions.
 
-`worldcoords` must be provided in the order of `dims(img)`.
+By default the result contains one 1-based slice-local pixel coordinate per selected dim, in `dims(img)` order.
+With `parent = true` the world coordinates are inverted through the full parent-frame transform instead.
+Axes frozen by slicing contribute their exact world values, and the result contains parent pixel coordinates
+for **all** WCS axes, in WCS axis order.
+
+If the current slice drops a pixel axis that the remaining world axes depend on
+(e.g. one axis of a celestial longitude/latitude pair), the remaining world coordinates
+alone do not determine pixel coordinates and an `ArgumentError` is thrown.
+Invert through the full transform via `world_to_pixel(wcs(img, wcsn), fullworldcoords)` instead.
 """
 function FITSWCS.world_to_pixel(img::AstroImage, worldcoords; parent = false, wcsn = ' ')
-    if worldcoords isa Array{Float64}
-        worldcoords_prepared = worldcoords
-    else
-        worldcoords_prepared = [Float64(c) for c in worldcoords]
-    end
-    return _world_to_pixel(img, worldcoords_prepared; wcsn, parent)
-end
-
-# Internal worker backing `world_to_pixel`. Returns the parent-adjusted pixel coordinates.
-function _world_to_pixel(img::AstroImage, worldcoords; wcsn = ' ', parent = false)
-    # # Find the coordinates in the parent array.
-    # # Dimensional data
-    # worldcoords_floored = floor.(Int, worldcoords)
-    # worldcoords_frac = (worldcoords .- worldcoords_floored) .* step.(dims(img))
-    # parentcoords = getindex.(dims(img), worldcoords_floored) .+ worldcoords_frac
-    # Build a Float64 buffer sized to the WCS's full axis count; the loops below
-    # scatter this image's world coords into their WCS-axis positions.
-    # TODO: avoid allocation in case where refdims=() and worldcoords isa Array{Float64}
-    if ndims(worldcoords) > 1
-        worldcoords_prepared = zeros(wcs(img, wcsn).naxis, size(worldcoords, 2))
-    else
-        worldcoords_prepared = zeros(wcs(img, wcsn).naxis)
-    end
-    # TODO: unlike `pixel_to_world` (which has an `all` kwarg and filters its
-    # output to the selected dims), this returns coordinates for every WCS axis.
-    # Consider mirroring that: add an `all` kwarg and filter to the current slice.
-    # out = zeros(Float64, wcs(img,wcsn).naxis, size(worldcoords,2))
-    for (i, dim) in enumerate(dims(img))
-        j = wcsax(img, dim)
-        worldcoords_prepared[j, :] = worldcoords[i, :]
-    end
-    for dim in refdims(img)
-        j = wcsax(img, dim)
-        # Non numeric reference dims can be used, e.g. a polarization axis of symbols I, Q, U, etc.
-        if eltype(dim) <: Number
-            z = dim[1]
-        else
-            # Find the index of the symbol into the parent cube
-            parentrefdim = img.wcsdims[findfirst(d -> name(d) == name(dim), img.wcsdims)]
-            z = findfirst(==(first(dim)), collect(parentrefdim)) - 1
-        end
-        worldcoords_prepared[j, :] .= z
-    end
-
-    pixcoords_out = world_to_pixel(wcs(img, wcsn), worldcoords_prepared)
-
+    world = _f64(worldcoords)
+    size(world, 1) == length(dims(img)) || throw(
+        DimensionMismatch(
+            "Got $(size(world, 1)) world coordinates but the image has $(length(dims(img))) dimensions."
+        )
+    )
     if !parent
-        coordoffsets = zeros(wcs(img, wcsn).naxis)
-        coordsteps = zeros(wcs(img, wcsn).naxis)
-        for (i, dim) in enumerate(dims(img))
-            j = wcsax(img, dim)
-            coordoffsets[j] = first(dims(img)[i])
-            coordsteps[j] = step(dims(img)[i])
-        end
-        for dim in refdims(img)
-            j = wcsax(img, dim)
-            # Non numeric reference dims can be used, e.g. a polarization axis of symbols I, Q, U, etc.
-            if eltype(dim) <: Number
-                coordoffsets[j] = first(dim)
-                coordsteps[j] = step(dim)
-            else
-                # Find the index of the symbol into the parent cube
-                parentrefdim = img.wcsdims[findfirst(d -> name(d) == name(dim), img.wcsdims)]
-                z = findfirst(==(first(dim)), collect(parentrefdim))
-                coordoffsets[j] = z - 1
-                coordsteps[j] = 1
-            end
-        end
-
-        # `world_to_pixel` returns an immutable `SVector` for single-coordinate
-        # (vector) inputs, so apply the parent-frame correction as a fresh
-        # broadcast rather than mutating `pixcoords_out` in place.
-        pixcoords_out = (pixcoords_out .- coordoffsets .+ 1) ./ coordsteps
+        # Delegate to a `SlicedWCSTransform`, which fills axes frozen by slicing
+        # with their exact world values and returns slice-local pixel coordinates
+        # for the kept axes. Requires each selected dim to correspond to exactly
+        # one surviving world axis (`world_keep == pixel_keep`).
+        sw = _slicedwcs(img, wcsn)
+        sw.world_keep == sw.pixel_keep || throw(
+            ArgumentError(
+                "The current slice drops pixel axes that the remaining world axes depend on (e.g. one axis of a celestial lon/lat pair), so " *
+                "$(length(dims(img))) world coordinates do not determine pixel coordinates." *
+                " Invert through the full transform instead: `world_to_pixel(wcs(img, wcsn), fullworldcoords)`."
+            )
+        )
+        perm = _sliceperm(img)
+        return _permrows(world_to_pixel(sw, _permrows(world, invperm(perm))), perm)
     end
-    return pixcoords_out
+    # parent = true: fill a full world-coordinate buffer.
+    # User values for the selected dims, exact frozen-axis world values elsewhere
+    # (evaluated with one forward transform), and invert through the parent-frame transform.
+    w = wcs(img, wcsn)
+    W = ndims(world) > 1 ? zeros(w.naxis, size(world, 2)) : zeros(w.naxis)
+    if w.naxis > length(dims(img))
+        W .= pixel_to_world(img, ones(length(dims(img))); wcsn, all = true)
+    end
+    for (i, d) in enumerate(dims(img))
+        W[wcsax(img, d), :] .= world[i, :]
+    end
+    return world_to_pixel(w, W)
 end
 
 

--- a/test/general.jl
+++ b/test/general.jl
@@ -221,10 +221,12 @@ end
             worldf = pixel_to_world(img, p; wcsn = n)
             @test worldf ≈ pixel_to_world(w, p) rtol = 1.0e-8
             @test world_to_pixel(img, worldf; wcsn = n) ≈ p rtol = 1.0e-8
-            # `parent = true` treats inputs as parent-frame coordinates, applying
-            # only the 1→0-based shift before the raw transform (no dim scaling).
+            # `parent = true` treats inputs as parent-frame coordinates. For a
+            # non-sliced image the parent frame IS the slice-local frame, so it
+            # must agree with both the default path and the raw transform.
             worldp = pixel_to_world(img, p; wcsn = n, parent = true)
-            @test worldp ≈ pixel_to_world(w, p .- 1) rtol = 1.0e-8
+            @test worldp ≈ pixel_to_world(w, p) rtol = 1.0e-8
+            @test worldp ≈ worldf rtol = 1.0e-8
             @test world_to_pixel(img, worldp; wcsn = n, parent = true) ≈
                 world_to_pixel(w, worldp) rtol = 1.0e-8
         end
@@ -276,12 +278,75 @@ end
     for p in testpix
         world = pixel_to_world(sl, p)      # filtered to the two kept dims
         @test length(world) == 2
-        back = world_to_pixel(sl, world)   # returns all WCS axes
-        @test back[1:2] ≈ p rtol = 1.0e-8  # kept dims round-trip
+        back = world_to_pixel(sl, world)   # slice-local pixels for the kept dims
+        @test length(back) == 2
+        @test back ≈ p rtol = 1.0e-8       # round-trips
     end
 
-    # `all = true` additionally returns the frozen spectral world coordinate.
-    @test length(pixel_to_world(sl, [1.0, 1.0]; all = true)) == 3
+    # `all = true` additionally returns the frozen spectral world coordinate:
+    # the slice sits at parent index 2, so FREQ = CRVAL3 + (2 - CRPIX3) * CDELT3.
+    allworld = pixel_to_world(sl, [1.0, 1.0]; all = true)
+    @test length(allworld) == 3
+    @test allworld[3] ≈ 1.0e9 + 1.0e6 rtol = 1.0e-8
+
+    # Strided slices: slice-local pixel p maps to parent pixel (p-1)*step + first,
+    # so pixel 2 of cube[1:2:5, :, 1] is parent pixel 3.
+    st = cube[1:2:5, :, 1]
+    w = wcs(cube, ' ')
+    @test pixel_to_world(st, [2.0, 3.0]) ≈ pixel_to_world(w, [3.0, 3.0, 1.0])[1:2] rtol = 1.0e-8
+    @test world_to_pixel(st, pixel_to_world(st, [2.0, 3.0])) ≈ [2.0, 3.0] rtol = 1.0e-8
+
+    # Transposition: coordinates follow `dims(img)` order and are routed to WCS
+    # axes by dim name, so the same array element gives the same world values.
+    tr = permutedims(sl, (2, 1))
+    @test pixel_to_world(tr, [3.0, 2.0]) ≈ reverse(pixel_to_world(sl, [2.0, 3.0])) rtol = 1.0e-8
+    @test world_to_pixel(tr, pixel_to_world(tr, [3.0, 2.0])) ≈ [3.0, 2.0] rtol = 1.0e-8
+
+    # Slicing must preserve the parent dim -> WCS axis bookkeeping (`wcsdims`).
+    @test length(getfield(sl, :wcsdims)) == 3
+    @test collect(getfield(sl, :wcsdims)[3]) == collect(1:4)
+end
+
+@testset "coupled-axis slicing" begin
+    fname = tempname() * ".fits"
+    # World axes 1-2 depend on pixel axis 3 through off-diagonal PC terms.
+    hdr = Card[
+        Card("CTYPE1", "RA---TAN"), Card("CTYPE2", "DEC--TAN"), Card("CTYPE3", "FREQ"),
+        Card("CRVAL1", 10.0), Card("CRVAL2", 20.0), Card("CRVAL3", 1.0e9),
+        Card("CRPIX1", 3.0), Card("CRPIX2", 3.0), Card("CRPIX3", 2.0),
+        Card("CDELT1", -1.0e-3), Card("CDELT2", 1.0e-3), Card("CDELT3", 1.0e6),
+        Card("CUNIT1", "deg"), Card("CUNIT2", "deg"), Card("CUNIT3", "Hz"),
+        Card("PC1_1", 1.0), Card("PC2_2", 1.0), Card("PC3_3", 1.0),
+        Card("PC1_3", 0.2), Card("PC2_3", 0.1),
+    ]
+    write(fname, HDU[HDU(Primary, reshape(Float32[1:(5 * 6 * 4);], 5, 6, 4), hdr)])
+    cube = AstroImage(fname)
+
+    # Dropping the coupled spectral axis still yields an exact inverse: the
+    # sliced transform knows the frozen axis's exact world contribution.
+    sl = cube[:, :, 3]
+    for p in ([1.0, 1.0], [2.0, 4.0], [5.0, 6.0])
+        world = pixel_to_world(sl, p)
+        @test length(world) == 2
+        @test world_to_pixel(sl, world) ≈ p rtol = 1.0e-8
+    end
+
+    # Slicing away one axis of the celestial pair leaves world axes that depend
+    # on the dropped pixel axis: the forward transform still works per-dim, but
+    # the inverse is underdetermined and must fail loudly.
+    fname2 = tempname() * ".fits"
+    hdr2 = Card[
+        Card("CTYPE1", "RA---TAN"), Card("CTYPE2", "DEC--TAN"),
+        Card("CRVAL1", 10.0), Card("CRVAL2", 20.0),
+        Card("CRPIX1", 5.0), Card("CRPIX2", 5.0),
+        Card("CDELT1", -1.0e-3), Card("CDELT2", 1.0e-3),
+        Card("CUNIT1", "deg"), Card("CUNIT2", "deg"),
+    ]
+    write(fname2, HDU[HDU(Primary, reshape(Float32[1:100;], 10, 10), hdr2)])
+    img = AstroImage(fname2)
+    line = img[:, 5]
+    @test length(pixel_to_world(line, [3.0])) == 1
+    @test_throws ArgumentError world_to_pixel(line, [10.0])
 end
 
 @testset "polarization (symbol) axis slicing" begin
@@ -310,11 +375,16 @@ end
     for p in ([1.0, 1.0], [2.0, 3.0], [5.0, 6.0])
         world = pixel_to_world(sl, p)
         back = world_to_pixel(sl, world)
-        @test back[1:2] ≈ p rtol = 1.0e-8
+        @test back ≈ p rtol = 1.0e-8
     end
 
     # Integer world input is accepted (converted to Float64 internally).
     @test world_to_pixel(sl, [1, 89]) ≈ world_to_pixel(sl, [1.0, 89.0]) rtol = 1.0e-8
+
+    # The frozen STOKES world value corresponds to :Q's parent index (2):
+    # CRVAL3 + (2 - CRPIX3) * CDELT3 = 2. Requires the categorical refdim to be
+    # located within the preserved parent `wcsdims` lookup.
+    @test pixel_to_world(sl, [1.0, 1.0]; all = true)[3] ≈ 2.0 rtol = 1.0e-8
 end
 
 ##


### PR DESCRIPTION
Closes the loop on the `slice_wcs` integration discussed in https://github.com/JuliaAstro/AstroImages.jl/pull/113#discussion_r3552880797. Depends on https://github.com/JuliaAstro/FITSWCS.jl/pull/17.

## Motivation

This PR aims to adopt `FITSWCS.slice_wcs` to simplify the parent-frame bookkeeping here, and also fix several correctness bugs that were unearthed in the process.

## Bugs fixed

1. **Strided slices off by `step-1`**: Legacy mapped slice-local --> parent as `p*step + first - 1`. Correct is `(p-1)*step + first`. The formulas agree only when `step == 1`, so `img[1:2:9, :]` reported world coordinates one parent pixel off.
1. **Frozen refdims off by one pixel**: Dropped axes were fed `dim[1] - 1`. `pixel_to_world(slice; all = true)` reported, e.g., `FREQ = 1.0e9` where the truth for a slice at parent index 2 is `1.001e9`. (Also affected the slice-label values in `implot` titles.)
1. **`parent = true` shifted by one pixel**: `pixel_to_world(img, p; parent = true)` equaled `raw(p .- 1)`, disagreeing with the default path on an unsliced image and shifting WCS-grid extents in the plot recipes by one pixel.
1. **Coupled inverses were garbage**: `world_to_pixel` stuffed frozen *pixel indices* into *world* coordinate slots before inverting. Harmless only when axes are fully separable. Frozen axes now contribute their exact world values (one forward evaluation).
1. **Underdetermined inverses were silent**: Slicing one axis of a celestial lon/lat pair leaves world axes that depend on the dropped pixel axis. `world_to_pixel` now throws a descriptive `ArgumentError` (astropy's `SlicedLowLevelWCS` similarly refuses) instead of returning wrong pixels.
1. **`wcsdims` lost on every slice**: Both `rebuild` methods defaulted to recomputing `wcsdims` from the already-sliced dims (DimensionalData no longer routes slicing through `rebuildsliced`), which broke categorical (Stokes) refdim resolution *and* name-tracked transposition. `rebuild` now preserves the parent `wcsdims`.

## New architecture (`src/wcs.jl`)

- `pixel_to_world`: one body for all cases. Expand dims-ordered coords into the full parent frame (kept dims via their lookups, frozen refdims at their parent positions, degenerate header axes at CRPIX), evaluate the full transform, filter to the selected dims (`all = true` returns every axis).
- `world_to_pixel` (default): Delegates to a `SlicedWCSTransform` (`FITSWCS.slice_wcs`) describing the current view, guarded by `world_keep == pixel_keep`.
- `world_to_pixel(parent = true)`: Unchanged contract for the WCS-grid plot recipes (`naxis` coordinates, WCS axis order), now with exact frozen-axis world values.
- Both legacy scatter/gather bodies and the `_world_to_pixel` worker are deleted. Docstrings now document `wcsn` / `all` / `parent` and the 1-based FITS convention.

## ⚠️  Breaking / behavior changes

- **`world_to_pixel(img, ...)` returns `ndims(img)` slice-local coordinates** in `dims(img)` order (was: `naxis` parent-frame values), making it the actual inverse of `pixel_to_world`. Parent-frame output remains available via `parent = true`.
- **`world_to_pixel` throws** on slices that drop a pixel axis the remaining world axes depend on (was: silently wrong values).
- **`parent = true` no longer shifted by one pixel**. WCS grid overlays now land at their true positions.
- Strided-slice and frozen-axis coordinates corrected per bugs 1–2 above.