### PR TITLE
feat: Support `scale` kwd from FITSFiles.jl

### DIFF
--- a/docs/src/manual/loading-and-saving-images.md
+++ b/docs/src/manual/loading-and-saving-images.md
@@ -54,6 +54,16 @@ hdu1, hdu2, hdu3 = load("multiext.fits", :); # Can also unpack multiple HDUs
 
 There is also limited support for table HDUs. In this case, a bare-bones Tables.jl compatible object is returned.
 
+## Scaled Data
+
+Many instruments store integer pixel values along with the `BSCALE` and `BZERO` keywords that convert them to physical units. By default, FITSFiles.jl applies this conversion as the file is read, so the image you get back holds the physical values. Pass `scale = false` to any of the loading functions to read the values exactly as they are stored on disk instead:
+
+```julia
+img = load("myfitsimg.fits"; scale = false)
+
+img = AstroImage("myfitsimg.fits", 1; scale = false)
+```
+
 ## Dimension Names
 
 You may have noticed the entries above the image array:

--- a/src/io.jl
+++ b/src/io.jl
@@ -20,16 +20,19 @@ Given a FITSFiles HDU, load it as an AstroImage.
 AstroImage(hdu::HDU, args...; kwargs...) = _loadhdu(hdu, args...; kwargs...)
 
 """
-    img = AstroImage(filename::AbstractString, ext::Integer=1)
+    img = AstroImage(filename::AbstractString, ext::Integer=1; scale=true)
 
 Load an image HDU `ext` from the FITS file at `filename` as an AstroImage.
+
+Set `scale=false` to load the data exactly as stored on disk, without applying
+the `BSCALE` and `BZERO` keywords.
 """
-function AstroImage(filename::AbstractString, ext::Integer, args...; kwargs...)
-    hdus = fits(filename)
+function AstroImage(filename::AbstractString, ext::Integer, args...; scale = true, kwargs...)
+    hdus = fits(filename; scale)
     return AstroImage(hdus[ext], args...; kwargs...)
 end
 """
-    img1, img2 = AstroImage(filename::AbstractString, exts)
+    img1, img2 = AstroImage(filename::AbstractString, exts; scale=true)
 
 Load multiple image HDUs `exts` from an FITS file at `filename` as an AstroImage.
 `exts` must be a tuple, range, :, or array of Integers.
@@ -46,20 +49,21 @@ function AstroImage(
         filename::AbstractString,
         exts::Union{NTuple{N, <:Integer}, AbstractArray{<:Integer}},
         args...;
+        scale = true,
         kwargs...
     ) where {N}
-    hdus = fits(filename)
+    hdus = fits(filename; scale)
     return map(exts) do ext
         return AstroImage(hdus[ext], args...; kwargs...)
     end
 end
-function AstroImage(filename::AbstractString; kwargs...)
-    hdus = fits(filename)
+function AstroImage(filename::AbstractString; scale = true, kwargs...)
+    hdus = fits(filename; scale)
     ext = indexer(hdus)
     return AstroImage(hdus[ext]; kwargs...)
 end
-function AstroImage(filename::AbstractString, ::Colon, args...; kwargs...)
-    hdus = fits(filename)
+function AstroImage(filename::AbstractString, ::Colon, args...; scale = true, kwargs...)
+    hdus = fits(filename; scale)
     return map(hdus) do hdu
         return AstroImage(hdu, args...; kwargs...)
     end
@@ -88,23 +92,27 @@ returned as AstroImage, and table HDUs are returned as column tables.
 Read and return the data from the HDUs given by `exts`. Image HDUs are
 returned as AstroImage, and table HDUs are returned as column tables.
 
+All of these accept a `scale` keyword, forwarded to FITSFiles. It defaults to
+`true`, applying the `BSCALE` and `BZERO` keywords to the data; pass
+`scale=false` to read the values exactly as stored on disk.
+
 !!! Currently any header on table HDUs are not supported and are ignored.
 """
-function fileio_load(f::File{format"FITS"}, ext::Union{Int, Nothing} = nothing, args...; kwargs...)
-    hdus = fits(f.filename)
+function fileio_load(f::File{format"FITS"}, ext::Union{Int, Nothing} = nothing, args...; scale = true, kwargs...)
+    hdus = fits(f.filename; scale)
     if isnothing(ext)
         ext = indexer(hdus)
     end
     return _loadhdu(hdus[ext], args...; kwargs...)
 end
-function fileio_load(f::File{format"FITS"}, exts::Union{NTuple{N, <:Integer}, AbstractArray{<:Integer}}, args...; kwargs...) where {N}
-    hdus = fits(f.filename)
+function fileio_load(f::File{format"FITS"}, exts::Union{NTuple{N, <:Integer}, AbstractArray{<:Integer}}, args...; scale = true, kwargs...) where {N}
+    hdus = fits(f.filename; scale)
     return map(exts) do ext
         _loadhdu(hdus[ext], args...; kwargs...)
     end
 end
-function fileio_load(f::File{format"FITS"}, ::Colon, args...; kwargs...)
-    hdus = fits(f.filename)
+function fileio_load(f::File{format"FITS"}, ::Colon, args...; scale = true, kwargs...)
+    hdus = fits(f.filename; scale)
     return map(hdus) do hdu
         _loadhdu(hdu, args...; kwargs...)
     end

--- a/test/general.jl
+++ b/test/general.jl
@@ -115,6 +115,36 @@ end
     rm(fname, force = true)
 end
 
+@testset "scale keyword" begin
+    # BSCALE/BZERO are applied by FITSFiles when reading, unless `scale=false` is
+    # forwarded to it, in which case the raw stored values are returned.
+    fname = tempname() * ".fits"
+    raw = reshape(Int16[1:20;], 4, 5)
+    cards = Card[Card("BZERO", 100.0), Card("BSCALE", 2.0)]
+    write(fname, HDU[HDU(Primary, raw, cards)])
+
+    scaled = 100 .+ 2 .* raw
+    for img in (AstroImage(fname), AstroImage(fname, 1), load(fname), load(fname, 1))
+        @test eltype(img) === Float32
+        @test img == scaled
+    end
+    for img in (
+            AstroImage(fname; scale = false), AstroImage(fname, 1; scale = false),
+            load(fname; scale = false), load(fname, 1; scale = false),
+        )
+        @test eltype(img) === Int16
+        @test img == raw
+    end
+
+    # Multi-HDU forms take the keyword too.
+    @test all(==(raw), AstroImage(fname, (1, 1); scale = false))
+    @test all(==(raw), AstroImage(fname, :; scale = false))
+    @test all(==(raw), load(fname, (1, 1); scale = false))
+    @test all(==(raw), load(fname, :; scale = false))
+
+    rm(fname, force = true)
+end
+
 @testset "Utility functions" begin
     @test size(AstroImage(rand(10, 10))) == (10, 10)
     @test length(AstroImage(rand(10, 10))) == 100


### PR DESCRIPTION
Now we can do `img = load(myfile.fits; scale = false)` to read the data as exactly stored on disk